### PR TITLE
Rectify make install issue and improve cmake function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/cmake/InfluxDBConf
 )
 
 # Install headers
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/InfluxDB DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 # Export targets
 install(EXPORT InfluxDBTargets

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ __Dependencies:__
 
  __Compilation__
  ```bash
- git clone https://github.com/awegrzyn/influxdb-cxx.git
- cd influxdb-cxx; mkdir build
- cmake -H. -Bbuild
- cmake --build build
- sudo make -C build install
+git clone https://github.com/awegrzyn/influxdb-cxx.git
+cd influxdb-cxx; mkdir build
+cd build
+cmake ..
+sudo make install
  ```
 
 ## Quick start


### PR DESCRIPTION
Had a few issues trying to install and use this recently using cmake 3.14. The -H option is deprecated and isn't available in the docs, apparently it's help now. 
By cd'ing to the build directory there is less typing