### PR TITLE
Removed description from project in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ endif()
 # Define project
 project(influxdb-cxx
   VERSION 0.0.1
-  DESCRIPTION "InfluxDB C++ client library"
   LANGUAGES CXX
 )
 


### PR DESCRIPTION
Description is not supported in new versions of CMake as seen here: https://cmake.org/cmake/help/v3.7/command/project.html