### PR TITLE
Exclude InfluxDB::query() if boost is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
 set(INCLUDE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/include")
 
-set(SRCS
+# Create library
+add_library(InfluxDB SHARED
   src/InfluxDB.cxx
   src/Point.cxx
   src/InfluxDBFactory.cxx
@@ -73,9 +74,6 @@ set(SRCS
   $<$<BOOL:${Boost_FOUND}>:src/UnixSocket.cxx>
   src/HTTP.cxx
 )
-
-# Create library
-add_library(InfluxDB SHARED ${SRCS})
 target_include_directories(InfluxDB
   PUBLIC
     $<INSTALL_INTERFACE:include>

--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -36,10 +36,8 @@ class InfluxDB
     /// \param metric
     void write(Point&& metric);
 
-#ifdef INFLUXDB_WITH_BOOST
     /// Queries InfluxDB database
     std::vector<Point> query(const std::string& query);
-#endif
 
     /// Flushes metric buffer (this can also happens when buffer is full)
     void flushBuffer();

--- a/include/InfluxDB.h
+++ b/include/InfluxDB.h
@@ -36,8 +36,10 @@ class InfluxDB
     /// \param metric
     void write(Point&& metric);
 
+#ifdef INFLUXDB_WITH_BOOST
     /// Queries InfluxDB database
     std::vector<Point> query(const std::string& query);
+#endif
 
     /// Flushes metric buffer (this can also happens when buffer is full)
     void flushBuffer();

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -7,9 +7,11 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#ifdef INFLUXDB_WITH_BOOST
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#endif
 
 namespace influxdb
 {
@@ -73,6 +75,7 @@ void InfluxDB::write(Point&& metric)
   }
 }
 
+#ifdef INFLUXDB_WITH_BOOST
 std::vector<Point> InfluxDB::query(const std::string&  query)
 {
   auto response = mTransport->query(query);
@@ -112,5 +115,6 @@ std::vector<Point> InfluxDB::query(const std::string&  query)
   }
   return points;
 }
+#endif
 
 } // namespace influxdb

--- a/src/InfluxDB.cxx
+++ b/src/InfluxDB.cxx
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+
 #ifdef INFLUXDB_WITH_BOOST
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -114,6 +115,11 @@ std::vector<Point> InfluxDB::query(const std::string&  query)
     }
   }
   return points;
+}
+#else
+std::vector<Point> InfluxDB::query(const std::string& /*query*/)
+{
+  throw std::runtime_error("InfluxDB query() requires boost");
 }
 #endif
 


### PR DESCRIPTION
Added extra `#ifdef` to exclude the `query()` function if boost is not found.
This way, the statement "boost (optional)" hold up.