### PR TITLE
Added support to long long int injection

### DIFF
--- a/include/Point.h
+++ b/include/Point.h
@@ -26,7 +26,7 @@ class Point
     Point&& addTag(std::string_view key, std::string_view value);
 
     /// Adds filed
-    Point&& addField(std::string_view name, std::variant<int, std::string, double> value);
+    Point&& addField(std::string_view name, std::variant<int, long long int, std::string, double> value);
 
     /// Generetes current timestamp
     static auto getCurrentTimestamp() -> decltype(std::chrono::system_clock::now());
@@ -48,7 +48,7 @@ class Point
 
   protected:
     /// A value
-    std::variant<int, std::string, double> mValue;
+    std::variant<long long int, std::string, double> mValue;
 
     /// A name
     std::string mMeasurement;

--- a/src/Point.cxx
+++ b/src/Point.cxx
@@ -23,7 +23,7 @@ Point::Point(const std::string& measurement) :
   mFields = {};
 }
 
-Point&& Point::addField(std::string_view name, std::variant<int, std::string, double> value)
+Point&& Point::addField(std::string_view name, std::variant<int, long long int, std::string, double> value)
 {
   std::stringstream convert;
   if (!mFields.empty()) convert << ",";
@@ -31,6 +31,7 @@ Point&& Point::addField(std::string_view name, std::variant<int, std::string, do
   convert << name << "=";
   std::visit(overloaded {
     [&convert](int value) { convert << value << 'i'; },
+    [&convert](long long int value) { convert << value << 'i'; },
     [&convert](double value) { convert << value; },
     [&convert](const std::string& value) { convert << '"' << value << '"'; },
     }, value);

--- a/test/testHttp.cxx
+++ b/test/testHttp.cxx
@@ -21,6 +21,10 @@ BOOST_AUTO_TEST_CASE(write1)
     .addField("value", 20)
     .addTag("host", "localhost")
   );
+
+  influxdb->write(Point{"test"}
+    .addField("value", 200LL)
+    .addTag("host", "localhost"));
 }
 
 } // namespace test

--- a/test/testPoint.cxx
+++ b/test/testPoint.cxx
@@ -18,7 +18,7 @@ std::vector<std::string> getVector(const Point& point)
 BOOST_AUTO_TEST_CASE(test1)
 {
   auto point = Point{"test"}
-    .addField("value", 10);
+    .addField("value", 10LL);
 
   auto result = getVector(point);
 
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(test1)
 BOOST_AUTO_TEST_CASE(test2)
 {
   auto point = Point{"test"}
-    .addField("value", 10)
+    .addField("value", 10LL)
     .addField("dvalue", 10.10);
 
   auto result = getVector(point);
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(test2)
 BOOST_AUTO_TEST_CASE(test3)
 {
   auto point = Point{"test"}
-    .addField("value", 10)
+    .addField("value", 10LL)
     .addField("dvalue", 10.10)
     .addTag("tag", "tagval");
 
@@ -55,6 +55,7 @@ BOOST_AUTO_TEST_CASE(test4)
 {
   auto point = Point{"test"}
     .addField("value", 10)
+    .addField("value", 100LL)
     .setTimestamp(std::chrono::time_point<std::chrono::system_clock>(std::chrono::milliseconds(1572830914)));
 
   auto result = getVector(point);

--- a/test/testQuery.cxx
+++ b/test/testQuery.cxx
@@ -12,11 +12,13 @@ namespace test {
 BOOST_AUTO_TEST_CASE(query1)
 {
   auto influxdb = influxdb::InfluxDBFactory::Get("http://localhost:8086?db=test");
-  auto points = influxdb->query("SELECT * from test LIMIT 2");
-  BOOST_CHECK_EQUAL(points.front().getName(), "test");
-  BOOST_CHECK_EQUAL(points.back().getName(), "test");
-  BOOST_CHECK_EQUAL(points.front().getFields(), "value=10");
-  BOOST_CHECK_EQUAL(points.back().getFields(), "value=20");
+  auto points = influxdb->query("SELECT * from test LIMIT 3");
+  BOOST_CHECK_EQUAL(points[0].getName(), "test");
+  BOOST_CHECK_EQUAL(points[1].getName(), "test");
+  BOOST_CHECK_EQUAL(points[2].getName(), "test");
+  BOOST_CHECK_EQUAL(points[0].getFields(), "value=10");
+  BOOST_CHECK_EQUAL(points[1].getFields(), "value=20");
+  BOOST_CHECK_EQUAL(points[2].getFields(), "value=200");
 }
 
 } // namespace test

--- a/test/testUdp.cxx
+++ b/test/testUdp.cxx
@@ -12,6 +12,8 @@ BOOST_AUTO_TEST_CASE(test)
   auto influxdb = influxdb::InfluxDBFactory::Get("udp://localhost:8084");
   influxdb->write(Point{"test"}
     .addField("value", 10)
+    .addField("value", 20)
+    .addField("value", 100LL)
     .addTag("host", "adampc")
   );
 }
@@ -23,6 +25,9 @@ BOOST_AUTO_TEST_CASE(test2)
   influxdb->write(Point{"test"}.addField("value", 10));
   influxdb->write(Point{"test"}.addField("value", 10));
   influxdb->write(Point{"test"}.addField("value", 10));
+  influxdb->write(Point{"test"}.addField("value", 100LL));
+  influxdb->write(Point{"test"}.addField("value", 100LL));
+  influxdb->write(Point{"test"}.addField("value", 100LL));
 }
 
 } // namespace test


### PR DESCRIPTION
InfluxDB support injection of 64 bits integers. Current approach only allowed injection of int (16 or 32 bits depending on platform)

Modified test to cover new feature